### PR TITLE
configurable terminal size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 [dependencies]
 clap = "2.33"
 nix = "0.18"
+terminal_size = "0.1.16"
 
 [dev-dependencies]
 scratch = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,9 +45,7 @@ fn try_main() -> Result<Exec> {
     let size = {
         use terminal_size::{terminal_size, Height, Width};
 
-        let parent_size = terminal_size()
-            .map(|(Width(w), Height(h))| (w, h))
-            .unwrap_or((80, 24));
+        let parent_size = terminal_size().map_or((80, 24), |(Width(w), Height(h))| (w, h));
         (
             size.0.unwrap_or(parent_size.0),
             size.1.unwrap_or(parent_size.1),


### PR DESCRIPTION
This proxies the current terminal's dimensions (columns, rows) to the child pty or uses the defaults (80, 24).
We also add CLI flags for customizing either or both of these options (width, height).

#### `faketty --help`

```console
faketty 1.0.1

USAGE:
    faketty [OPTIONS] -- <program> <args...>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -H, --height <height>    Sets the height of the pty
    -W, --width <width>      Sets the width of the pty

ARGS:
    <program>...
```

#### `faketty -H this_tall -- ls -shal`

```console
error: Invalid value for '--height <height>': must be a number
```