### PR TITLE
Turn on deny(unsafe_op_in_unsafe_fn)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ unsafe fn forkpty() -> Result<ForkptyResult> {
         ws_ypixel: 0,
     };
     let termios = None;
-    let result = pty::forkpty(&winsize, termios)?;
+    let result = unsafe { pty::forkpty(&winsize, termios) }?;
     Ok(result)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_op_in_unsafe_fn)]
 #![allow(
     clippy::empty_enum,
     clippy::let_underscore_untyped,


### PR DESCRIPTION
This is allow-by-default for now in 2021 edition, but will become warn-by-default in 2024 edition.