### PR TITLE
Turn into library + binary with minimal changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faketty"
-version = "1.0.18"
+version = "1.0.19"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 categories = ["command-line-utilities", "os::unix-apis"]
 description = "Wrapper to exec a command in a pty, even if redirecting the output"
@@ -9,8 +9,16 @@ keywords = ["tty"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/faketty"
 
+[[bin]]
+name = "faketty"
+required-features = ["binary"]
+
+[features]
+default = ["binary"]
+binary = ["dep:clap"]
+
 [dependencies]
-clap = { version = "4", features = ["deprecated"] }
+clap = { version = "4", features = ["deprecated"], optional = true }
 nix = { version = "0.29", default-features = false, features = ["fs", "process", "term"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ streams.
 
 <br>
 
+## As a library
+
+`faketty` can be added to the [`dev-dependencies`] of cargo projects,
+in which case we can drop the default `clap` crate (for command line argument parsing)
+with `--no-default-features`:
+
+```bash
+cargo add faketty --dev --no-default-features
+```
+
+Note that `faketty::run_command` calls [`exec(3)`], therefore the child process
+will replace the current (parent) process.
+
+[`exec(3)`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html
+
+<br>
+
 #### License
 
 <sup>

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ with `--no-default-features`:
 cargo add faketty --dev --no-default-features
 ```
 
+A minimal example of the library usage is provided under [examples](./examples).
 Note that `faketty::run_command` calls [`exec(3)`], therefore the child process
 will replace the current (parent) process.
 

--- a/examples/faketty-min.rs
+++ b/examples/faketty-min.rs
@@ -1,0 +1,46 @@
+//! Minimal example of `faketty` without the `clap` dependency
+
+use faketty::run_command;
+
+fn main() -> () {
+    let mut args = std::env::args();
+    let arg0 = args.next().unwrap_or_default();
+    let arg0 = match (env!("CARGO_BIN_NAME").trim(), arg0.trim()) {
+        (x, _) if !x.is_empty() => x,
+        (_, x) if !x.is_empty() => x,
+        _ => "faketty",
+    };
+    let args: Vec<_> = args
+        .map(|x| std::ffi::CString::new(x.as_bytes()).unwrap())
+        .collect();
+    if args.is_empty() {
+        eprintln!("Usage: {arg0} <program> <args...>");
+        std::process::exit(1);
+    };
+    run_command(args).unwrap();
+}
+
+/// Tests itself with `cargo run --example`
+#[test]
+fn run_faketty_min() -> std::io::Result<()> {
+    use std::fs::{self, File};
+    use std::process::Command;
+
+    let tempdir = scratch::path(env!("CARGO_BIN_NAME"));
+    let stdout = tempdir.join("test-stdout");
+    let stderr = tempdir.join("test-stderr");
+
+    let cargo_args = format!("run --quiet --example={} --", env!("CARGO_BIN_NAME"));
+    let cargo_args: Vec<_> = cargo_args.split_whitespace().collect();
+    let status = Command::new("cargo")
+        .args(cargo_args)
+        .arg("tests/test.sh")
+        .stdout(File::create(&stdout)?)
+        .stderr(File::create(&stderr)?)
+        .status()?;
+
+    assert_eq!(status.code(), Some(6));
+    assert_eq!(fs::read(stdout)?, "stdout is tty\r\n".as_bytes());
+    assert_eq!(fs::read(stderr)?, "stderr is tty\r\n".as_bytes());
+    Ok(())
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,8 +3,11 @@ use std::io;
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
+/// Possible errors for the result of [`run_command`][crate::run_command].
 #[derive(Debug)]
-pub(crate) enum Error {
+#[non_exhaustive]
+#[allow(missing_docs)]
+pub enum Error {
     Nix(nix::Error),
     Io(io::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,105 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+#![allow(
+    clippy::empty_enum,
+    clippy::let_underscore_untyped,
+    clippy::needless_pass_by_value,
+    clippy::uninlined_format_args
+)]
+#![warn(missing_docs)]
+#![doc = include_str!("../README.md")]
+
+mod error;
+
+pub use crate::error::Error;
+use crate::error::Result;
+use nix::pty::{self, ForkptyResult, Winsize};
+use nix::sys::wait::{self, WaitStatus};
+use nix::unistd::{self, Pid};
+use std::ffi::CString;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
+use std::process;
+
+const STDIN: BorrowedFd = unsafe { BorrowedFd::borrow_raw(0) };
+const STDOUT: BorrowedFd = unsafe { BorrowedFd::borrow_raw(1) };
+const STDERR: BorrowedFd = unsafe { BorrowedFd::borrow_raw(2) };
+
+/// Empty enum for the result of [`run_command`].
+///
+/// Internally the process is replaced by [`execvp`][unistd::execvp]
+/// so this result should be unreachable. It is thus similar to
+/// [`std::convert::Infallible`].
+///
+pub enum Exec {}
+
+/// Runs a command in a pty, even if redirecting the output.
+///
+/// Internally the function calls [`exec(3)`], namely the child process will
+/// replace the current (parent) process.
+///
+/// [`exec(3)`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html
+///
+pub fn run_command(args: Vec<CString>) -> Result<Exec> {
+    let new_stdin = STDIN.try_clone_to_owned()?;
+    let new_stderr = STDERR.try_clone_to_owned()?;
+    let pty1 = unsafe { crate::forkpty() }?;
+    if let ForkptyResult::Parent { child, master } = pty1 {
+        crate::copyfd(master.as_fd(), STDOUT);
+        crate::copyexit(child);
+    }
+    let new_stdout = STDOUT.try_clone_to_owned()?;
+    let pty2 = unsafe { crate::forkpty() }?;
+    if let ForkptyResult::Parent { child, master } = pty2 {
+        crate::copyfd(master.as_fd(), new_stderr.as_fd());
+        crate::copyexit(child);
+    }
+    unistd::dup2(new_stdin.as_raw_fd(), STDIN.as_raw_fd())?;
+    unistd::dup2(new_stdout.as_raw_fd(), STDOUT.as_raw_fd())?;
+    crate::exec(args)
+}
+
+unsafe fn forkpty() -> Result<ForkptyResult> {
+    let winsize = Winsize {
+        ws_row: 24,
+        ws_col: 80,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let termios = None;
+    let result = unsafe { pty::forkpty(&winsize, termios) }?;
+    Ok(result)
+}
+
+fn exec(args: Vec<CString>) -> Result<Exec> {
+    let args: Vec<_> = args.iter().map(CString::as_c_str).collect();
+    unistd::execvp(args[0], &args)?;
+    unreachable!();
+}
+
+fn copyfd(read: BorrowedFd, write: BorrowedFd) {
+    const BUF: usize = 4096;
+    let mut buf = [0; BUF];
+    loop {
+        match unistd::read(read.as_raw_fd(), &mut buf) {
+            Ok(0) | Err(_) => return,
+            Ok(n) => {
+                let _ = write_all(write, &buf[..n]);
+            }
+        }
+    }
+}
+
+fn write_all(fd: BorrowedFd, mut buf: &[u8]) -> Result<()> {
+    while !buf.is_empty() {
+        let n = unistd::write(fd, buf)?;
+        buf = &buf[n..];
+    }
+    Ok(())
+}
+
+fn copyexit(child: Pid) -> ! {
+    let flag = None;
+    process::exit(match wait::waitpid(child, flag) {
+        Ok(WaitStatus::Exited(_pid, code)) => code,
+        _ => 0,
+    });
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,28 +1,13 @@
-#![deny(unsafe_op_in_unsafe_fn)]
-#![allow(
-    clippy::empty_enum,
-    clippy::let_underscore_untyped,
-    clippy::needless_pass_by_value,
-    clippy::uninlined_format_args
-)]
-
-mod error;
-
-use crate::error::Result;
 use clap::{Arg, ArgAction, Command};
-use nix::pty::{self, ForkptyResult, Winsize};
-use nix::sys::wait::{self, WaitStatus};
-use nix::unistd::{self, Pid};
 use std::ffi::{CString, OsString};
 use std::io::{self, Write};
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
 use std::os::unix::ffi::OsStrExt;
 use std::process;
 
-enum Exec {}
+use faketty::run_command;
 
 fn main() -> ! {
-    match try_main() {
+    match run_command(crate::args()) {
         Err(err) => {
             let _ = writeln!(io::stderr(), "faketty: {}", err);
             process::exit(1);
@@ -30,30 +15,6 @@ fn main() -> ! {
         #[allow(unreachable_patterns)]
         Ok(exec) => match exec {},
     }
-}
-
-const STDIN: BorrowedFd = unsafe { BorrowedFd::borrow_raw(0) };
-const STDOUT: BorrowedFd = unsafe { BorrowedFd::borrow_raw(1) };
-const STDERR: BorrowedFd = unsafe { BorrowedFd::borrow_raw(2) };
-
-fn try_main() -> Result<Exec> {
-    let args = crate::args();
-    let new_stdin = STDIN.try_clone_to_owned()?;
-    let new_stderr = STDERR.try_clone_to_owned()?;
-    let pty1 = unsafe { crate::forkpty() }?;
-    if let ForkptyResult::Parent { child, master } = pty1 {
-        crate::copyfd(master.as_fd(), STDOUT);
-        crate::copyexit(child);
-    }
-    let new_stdout = STDOUT.try_clone_to_owned()?;
-    let pty2 = unsafe { crate::forkpty() }?;
-    if let ForkptyResult::Parent { child, master } = pty2 {
-        crate::copyfd(master.as_fd(), new_stderr.as_fd());
-        crate::copyexit(child);
-    }
-    unistd::dup2(new_stdin.as_raw_fd(), STDIN.as_raw_fd())?;
-    unistd::dup2(new_stdout.as_raw_fd(), STDOUT.as_raw_fd())?;
-    crate::exec(args)
 }
 
 fn app() -> Command {
@@ -100,53 +61,6 @@ fn args() -> Vec<CString> {
         .unwrap()
         .map(|os_string| CString::new(os_string.as_bytes()).unwrap())
         .collect()
-}
-
-unsafe fn forkpty() -> Result<ForkptyResult> {
-    let winsize = Winsize {
-        ws_row: 24,
-        ws_col: 80,
-        ws_xpixel: 0,
-        ws_ypixel: 0,
-    };
-    let termios = None;
-    let result = unsafe { pty::forkpty(&winsize, termios) }?;
-    Ok(result)
-}
-
-fn exec(args: Vec<CString>) -> Result<Exec> {
-    let args: Vec<_> = args.iter().map(CString::as_c_str).collect();
-    unistd::execvp(args[0], &args)?;
-    unreachable!();
-}
-
-fn copyfd(read: BorrowedFd, write: BorrowedFd) {
-    const BUF: usize = 4096;
-    let mut buf = [0; BUF];
-    loop {
-        match unistd::read(read.as_raw_fd(), &mut buf) {
-            Ok(0) | Err(_) => return,
-            Ok(n) => {
-                let _ = write_all(write, &buf[..n]);
-            }
-        }
-    }
-}
-
-fn write_all(fd: BorrowedFd, mut buf: &[u8]) -> Result<()> {
-    while !buf.is_empty() {
-        let n = unistd::write(fd, buf)?;
-        buf = &buf[n..];
-    }
-    Ok(())
-}
-
-fn copyexit(child: Pid) -> ! {
-    let flag = None;
-    process::exit(match wait::waitpid(child, flag) {
-        Ok(WaitStatus::Exited(_pid, code)) => code,
-        _ => 0,
-    });
 }
 
 #[test]


### PR DESCRIPTION
`faketty` is a powerful binary for capturing colored outputs when testing CLI apps, so it would be great if it can be used as a dev dependency. However, before the eventual stabilization of [`artifact-dependencies`](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#artifact-dependencies), there is no way to pull it into the `[dev-dependencies]` in stable cargo, unless it is made into a library.

> The only other working alternative that I can find is [`portable_pty`](https://docs.rs/portable-pty/latest/portable_pty). It is more versatile than `faketty` but at the same time, much much heavier. So it's still valuable to have a `faketty` lib as a lean version.

Although the diff may seem large, this patch is mostly trivial: it simply splits out a `lib.rs` from `main.rs` such that `faketty` can be reused in cargo projects with `cargo add`:
- Rename `try_main` to `run_command` which takes `Vec<CString>` arguments. This is the only function exposed by the library, along with its possible results (`Exec` and `Error`).
- Make `clap` into an optional (but default) dependency. The library can then be reused without `clap`.
- Document the library use (in README and with doc-comments) and provide a minimal example under ./examples.

